### PR TITLE
Fix asset swapper + add pet/terrain swapper

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,1 +1,1 @@
-{"docassets":{"active":false,"customPet":"","pet":""},"rpc":{"active":false},"swapper":{}}
+{"docassets":{"active":false,"customPet":"","pet":""},"rpc":{"active":false}}

--- a/plugins/swapper/manifest.json
+++ b/plugins/swapper/manifest.json
@@ -9,9 +9,9 @@
    "declarative_net_request": {
       "rule_resources": [
             {
-	"id":"ruleset_1",
-	"enabled": true,
-	"path": "rule.json"
+	            "id":"ruleset_1",
+	            "enabled": true,
+	            "path": "rule.json"
             }
        ]
    },

--- a/src/index.html
+++ b/src/index.html
@@ -329,7 +329,29 @@
                                 </select>
                             </td>
                             <td>
-                                <input class="ext-input" type="text" placeholder="Enter terrain url" id="terrain-input">
+                                <!-- <input class="ext-input" type="text" placeholder="Enter terrain url" id="terrain-input"> -->
+                                <select class="ext-input ext-dropdown" id="terrain-input">
+                                    <option value="" disabled="" selected="">Select a terrain texture</option>
+                                    <option value="1">terrain</option>
+                                    <option value="2">terrain_back</option>
+                                    <option value="3">coldterrain</option>
+                                    <option value="4">coldterrain_back</option>
+                                    <option value="5">deepterrain</option>
+                                    <option value="6">beach</option>
+                                    <option value="7">beach_underwater</option>
+                                    <option value="8">swamp_island</option>
+                                    <option value="9">glacier</option>
+                                    <option value="10">reef</option>
+                                    <option value="11">reef2</option>
+                                    <option value="12">cenote1</option>
+                                    <option value="13">chalk</option>
+                                    <option value="14">clay</option>
+                                    <option value="15">estuarysand</option>
+                                    <option value="16">limestone</option>
+                                    <option value="17">rustymetal</option>
+                                    <option value="18">shallowglacier</option>
+                                    <option value="19">volcanicsand</option>
+                                </select>
                             </td>
                         </tr>
                         <tr>

--- a/src/index.html
+++ b/src/index.html
@@ -176,6 +176,11 @@
         border-radius: 5px;
         padding: 5px;
     }
+    .ext-dropdown {
+        font-family: inherit;
+        font-size: inherit;
+        width: 100%;
+    }
 
     #extensions {
         right: 50%;
@@ -302,7 +307,26 @@
                         <td>Terrain/Pet Swapper</td>
                         <tr class="option" id="doc-enable">
                             <td>
-                                <input class="ext-input" type="text" placeholder="Enter pet url" id="pet-input">
+                                <!-- <input class="ext-input" type="text" placeholder="Enter pet url" id="pet-input"> -->
+                                <select class="ext-input ext-dropdown" id="pet-input">
+                                    <option value="" disabled="" selected="">Select a pet</option>
+                                    <option value="alfonsino.png">alfonsino.png</option>
+                                    <option value="amphipod.png">amphipod.png</option>
+                                    <option value="blanquillo.png">blanquillo.png</option>
+                                    <option value="combjelly.png">combjelly.png</option>
+                                    <option value="cystisoma.png">cystisoma.png</option>
+                                    <option value="fusilier.png">fusilier.png</option>
+                                    <option value="gunnel.png">gunnel.png</option>
+                                    <option value="killifish.png">killifish.png</option>
+                                    <option value="peapuffer.png">peapuffer.png</option>
+                                    <option value="pineapplefish.png">pineapplefish.png</option>
+                                    <option value="poacher.png">poacher.png</option>
+                                    <option value="scad.png">scad.png</option>
+                                    <option value="shrimp.png">shrimp.png</option>
+                                    <option value="stickleback.png">stickleback.png</option>
+                                    <option value="stubbysquid.png">stubbysquid.png</option>
+                                    <option value="triplefin.png">triplefin.png</option>
+                                </select>
                             </td>
                             <td>
                                 <input class="ext-input" type="text" placeholder="Enter terrain url" id="terrain-input">

--- a/src/plugins.go
+++ b/src/plugins.go
@@ -110,11 +110,11 @@ func CheckAndLogFatal(e error) {
 
 func (p *PluginManager) AddPlugins() {
 	p.AddPlugin(EXTENSION, "Docassets", "docassets", Config{
-		"active": true, 
-		"pet": "", 
+		"active":    true,
+		"pet":       "",
 		"customPet": "",
 	})
-	p.AddPlugin(EXTENSION, "Swapper", "swapper", Config{})
+	// p.AddPlugin(EXTENSION, "Swapper", "swapper", Config{})
 	p.AddPlugin(SCRIPT, "DiscordRPC", "rpc", Config{"active": false})
 	// p.AddPlugin(EXTENSION, "DeeeepioBGM", "deeeepio_bgm", Config{})
 }

--- a/src/script.js
+++ b/src/script.js
@@ -3,6 +3,17 @@
 document.addEventListener('contextmenu', (e) => e.preventDefault())
 
 document.addEventListener("DOMContentLoaded", () => {
+  // Hook the gameScene
+  let gameScene;
+  const originalBind = Function.prototype.bind;
+  Function.prototype.bind = function (...args) {
+      if (args[0]?.gameScene) {
+          gameScene = args[0];
+      }
+
+      return originalBind.apply(this, args);
+  };
+
   const navBar = document.getElementsByClassName("el-row top-right-nav items-center")[0]
   const updateLog = document.createElement("div")
   updateLog.innerHTML = `<div class="tr-menu-button ext-yellow" style="padding-right: 4px; padding-left: 4px;"><div class="el-dropdown nice-dropdown" data-v-7db8124a="" data-v-190e0e28=""><button class="el-button el-button--small el-tooltip__trigger btn nice-button yellow has-icon square only-icon el-tooltip__trigger" aria-disabled="false" type="button" id="el-id-9348-12" role="button" tabindex="0" aria-controls="el-id-9348-13" aria-expanded="false" aria-haspopup="menu" data-v-1676d978="" data-v-7db8124a=""><!--v-if--><span class=""><!----><!----></span>
@@ -59,8 +70,13 @@ document.addEventListener("DOMContentLoaded", () => {
   const swapperInput = document.getElementById("swapper-input")
   swapperBtn.addEventListener("click", () => {
     const id = parseInt(swapperInput.value)
-    gameScene.gameScene.game.currentScene.myAnimal.setSkin(id)
-    //console.log(`[DDC Asset Swapper] ${id}`)
+    // We need to try-catch this because gameScene might not exist
+    try {
+      gameScene.gameScene.myAnimals.forEach((animal) => animal.setSkin(id))
+    } catch (error) {
+      console.error(error)
+    }
+    console.log(`[DDC Asset Swapper] ${id}`)
   })
 
   // Terrain/Pet Swapper

--- a/src/script.js
+++ b/src/script.js
@@ -126,6 +126,16 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   };
 
+  // https://pixijs.download/v7.2.4/docs/PIXI.Assets.html
+  const allowedContentTypes = ["avif", "webp", "apng", "png", "jpeg", "gif", "svg+xml"].map((type) => `image/${type}`)
+  async function checkUrl (url) {
+    const response = await fetch(url, {
+        method: 'HEAD'
+    });
+    const contentType = response.headers.get("Content-Type");
+    return allowedContentTypes.includes(contentType)
+  };
+
   const petBtn = document.getElementById("pet-btn")
   const terrainBtn = document.getElementById("terrain-btn")
 
@@ -133,6 +143,9 @@ document.addEventListener("DOMContentLoaded", () => {
   terrainBtn.addEventListener("click", async () => {
     const targetTerrain = Number.parseInt(document.getElementById("terrain-input").value)
     const customUrl = document.getElementById("terrain-custom-input").value
+
+    const urlValid = await checkUrl(customUrl)
+    if (!urlValid) return alert("Invalid URL")
 
     // Check if the given URL is a texture that has been loaded before
     let cached = cachedCustomTerrain[customUrl]
@@ -176,6 +189,9 @@ document.addEventListener("DOMContentLoaded", () => {
     const targetPet = document.getElementById("pet-input").value
     const customUrl = document.getElementById("pet-custom-input").value
     
+    const urlValid = await checkUrl(customUrl)
+    if (!urlValid) return alert("Invalid URL")
+
     // Check if the given URL is a texture that has been loaded before
     let cached = cachedCustomPets[customUrl]
     if (!cached) {


### PR DESCRIPTION
This pull request restores the original function of the asset swapper. It also adds functionality for the pet and terrain swapper. None of these swappers (animal skin, pet, and terrain texture) require a page reload to take effect. 

## How the pet/terrain swapper works
In PixiJS v7.x, packages are all added to an object before it is exported as the `PIXI` object. It uses the `Object.defineProperty` function. A hook can be added to this built-in function to get the Assets package like so:
```js
let PixiAssets;
const ObjectDefineProperty = Object.defineProperty;
Object.defineProperty = function (...args) {
  if (args[0]?.loadTextures) {
    PixiAssets = args[0].Assets;
    Object.defineProperty = ObjectDefineProperty;
  }
  return ObjectDefineProperty.apply(this, args);
};
```

After this, you can load a texture from an image URL using 
```js
await PixiAssets.load({
  alias: [aliasName],
  src: url,
  data: {
    ignoreMultiPack: true
  }
});
```

### Pet
Changing the texture of a pet is super simple because Deeeep.io has functions that do most of the work for you. 
You can set `petData.asset` to an asset alias in the PixiJS asset cache, then call `updateTexture()`

### Terrain
Terrains in Deeeep.io were meant to have static textures and do not have any functions to easily update the texture. 
We need to manually clear the [Pixi Graphics](https://pixijs.download/v7.2.4/docs/PIXI.Graphics.html) object that the terrain is drawn on, then redraw it with the desired textureFill. 

```js
// Suppose "e" is a PixiJS Graphics object
const points = e.shape.geometry.graphicsData[0].shape.points
e.shape.clear()
e.shape.beginTextureFill({
  texture: cached, 
  color: "ffffff"
})
e.shape.moveTo(points.shift(), points.shift())
while (points.length > 0) {
  e.shape.lineTo(points.shift(), points.shift())
}
e.shape.closePath()
```