### PR TITLE
Fix issue with multiple pop-up windows appearing

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,9 +93,20 @@ func main() {
 		ui.Load(`https://deeeep.io` + plugins.QueryPlugins())
 		EvalDefaultScripts(&ui, plugins)
 	})
-	ui.Bind("makeWindow", func(content string, width int, height int) {
-		lorca.New("data:text/html,"+url.PathEscape(content), "", width, height, "--remote-allow-origins=*")
+
+	var windows map[string]lorca.UI = make(map[string]lorca.UI)
+	ui.Bind("makeWindow", func(content string, width int, height int, id string) {
+		existingWin, exists := windows[id]
+		if exists {
+			delete(windows, id)
+			existingWin.Close()
+		}
+		win, _ := lorca.New("data:text/html,"+url.PathEscape(content), "", width, height, "--remote-allow-origins=*")
+		windows[id] = win
+		<-win.Done()
+		delete(windows, id)
 	})
+
 	ui.Bind("exit", func() {
 		ui.Close()
 	})

--- a/src/script.js
+++ b/src/script.js
@@ -292,7 +292,7 @@ document.addEventListener("DOMContentLoaded", () => {
   </script>
   </html>`
   openList.addEventListener("click", () => {
-    makeWindow(listHTML, 463, 483)
+    makeWindow(listHTML, 463, 483, "animalList")
   })
 
   // Doc Assets
@@ -439,7 +439,7 @@ document.addEventListener("DOMContentLoaded", () => {
           </style>
           <script>window.addEventListener('contextmenu', (evt) => evt.preventDefault())</script>
         `
-        makeWindow(evoTree, 865, 663)
+        makeWindow(evoTree, 865, 663, "evoTree")
       }
     }
     keydown = true


### PR DESCRIPTION
This is pretty self-explanatory. 

`main.go` keeps track of all the pop-up windows. When the creation of a new window is requested, the old window will be closed. 